### PR TITLE
Access-Control-Allow-Origin header in env var, make API calls works too

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Refresh the page and confirm that your key is now saved and encrypted:
 
 You can now use your worker URL as an the RPC endpoint in all SDK and client side configurations without your API key leaking!
 # Additional Security Steps
-This implementaiton is intentionally left in a less-than-ideal security state to facilitate easy deployment by anyone. If you would like to 
+This implementation is intentionally left in a less-than-ideal security state to facilitate easy deployment by anyone. If you would like to
 lock down your RPC proxy further, consider the following steps after you have successfully deployed the worker:
 
 
-* Update the `Access-Control-Allow-Origin` header in `src/index.ts` to contain the host that your requests are coming from (usually your client application).
+* Update the `Access-Control-Allow-Origin` header by adding a new variable with the key name `CORS_ALLOW_ORIGIN` to contain the host that your requests are coming from (usually your client application). For example, if you wanted to allow requests from `https://example.com`, you would change the header to `https://example.com`.
 * [Cloudflare Web Application Firewall (WAF)](https://www.cloudflare.com/lp/ppc/waf-x/) - You can configure the WAF to inspect requests and allow/deny based on your own business logic.
 * Modify the IP address allow list in Helius for your API key to only accept connections from the Cloudflare ranges (https://cloudflare.com/ips-v4).

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,9 @@ export default {
       return await fetch(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, request)
     }
 
-		const {pathname} = new URL(request.url)
+		const {pathname, search} = new URL(request.url)
 		const payload = await request.text();
-		const proxyRequest = new Request(`https://${pathname === '/' ? 'rpc' : 'api'}.helius.xyz${pathname}?api-key=${env.HELIUS_API_KEY}`, {
+		const proxyRequest = new Request(`https://${pathname === '/' ? 'rpc' : 'api'}.helius.xyz${pathname}?api-key=${env.HELIUS_API_KEY}${search ? `&${search.slice(1)}` : ''}`, {
 			method: request.method,
 			body: payload || null,
 			headers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 interface Env {
+	CORS_ALLOW_ORIGIN: string;
 	HELIUS_API_KEY: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,11 @@ export default {
       return await fetch(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, request)
     }
 
-
+		const {pathname} = new URL(request.url)
 		const payload = await request.text();
-		const proxyRequest = new Request(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, {
-			method: "POST",
-			body: payload,
+		const proxyRequest = new Request(`https://${pathname === '/' ? 'rpc' : 'api'}.helius.xyz${pathname}?api-key=${env.HELIUS_API_KEY}`, {
+			method: request.method,
+			body: payload || null,
 			headers: {
 				'Content-Type': 'application/json',
 				'X-Helius-Cloudflare-Proxy': 'true',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,20 @@ interface Env {
 	HELIUS_API_KEY: string;
 }
 
-// If the request is an OPTIONS request, return a 200 response with permissive CORS headers
-// This is required for the Helius RPC Proxy to work from the browser and arbitrary origins
-// If you wish to restrict the origins that can access your Helius RPC Proxy, you can do so by
-// changing the `*` in the `Access-Control-Allow-Origin` header to a specific origin.
-// For example, if you wanted to allow requests from `https://example.com`, you would change the
-// header to `https://example.com`.
-const corsHeaders = {
-	"Access-Control-Allow-Origin": "*",
-	"Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
-	"Access-Control-Allow-Headers": "*",
-}
-
 export default {
 	async fetch(request: Request, env: Env) {
+
+		// If the request is an OPTIONS request, return a 200 response with permissive CORS headers
+		// This is required for the Helius RPC Proxy to work from the browser and arbitrary origins
+		// If you wish to restrict the origins that can access your Helius RPC Proxy, you can do so by
+		// changing the `*` in the `Access-Control-Allow-Origin` header to a specific origin.
+		// For example, if you wanted to allow requests from `https://example.com`, you would change the
+		// header to `https://example.com`.
+		const corsHeaders = {
+			"Access-Control-Allow-Origin": `${env.CORS_ALLOW_ORIGIN || '*'}`,
+			"Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
+			"Access-Control-Allow-Headers": "*",
+		}
 
 		if (request.method === "OPTIONS") {
 			return new Response(null, {
@@ -28,7 +28,7 @@ export default {
     if (upgradeHeader || upgradeHeader === 'websocket') {
       return await fetch(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, request)
     }
-		
+
 
 		const payload = await request.text();
 		const proxyRequest = new Request(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, {


### PR DESCRIPTION
1. It's easier to define `Access-Control-Allow-Origin` header directly in environnement variables on Cloudflare.
2. The proxy is also working for API calls