### PR TITLE
Add multiple domain support in Access-Control-Allow-Origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ This implementation is intentionally left in a less-than-ideal security state to
 lock down your RPC proxy further, consider the following steps after you have successfully deployed the worker:
 
 
-* Update the `Access-Control-Allow-Origin` header by adding a new variable with the key name `CORS_ALLOW_ORIGIN` to contain the host that your requests are coming from (usually your client application). For example, if you wanted to allow requests from `https://example.com`, you would change the header to `https://example.com`.
+* Update the `Access-Control-Allow-Origin` header by adding a new variable with the key name `CORS_ALLOW_ORIGIN` to contain the host that your requests are coming from (usually your client application). For example, if you wanted to allow requests from `https://example.com`, you would change the header to `https://example.com`. To support multiple domains, set `CORS_ALLOW_ORIGIN` to a comma separated list of domains (e.g. `https://example.com,https://beta.example.com`).
 * [Cloudflare Web Application Firewall (WAF)](https://www.cloudflare.com/lp/ppc/waf-x/) - You can configure the WAF to inspect requests and allow/deny based on your own business logic.
 * Modify the IP address allow list in Helius for your API key to only accept connections from the Cloudflare ranges (https://cloudflare.com/ips-v4).

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,20 @@ export default {
 		// If you wish to restrict the origins that can access your Helius RPC Proxy, you can do so by
 		// changing the `*` in the `Access-Control-Allow-Origin` header to a specific origin.
 		// For example, if you wanted to allow requests from `https://example.com`, you would change the
-		// header to `https://example.com`.
-		const corsHeaders = {
-			"Access-Control-Allow-Origin": `${env.CORS_ALLOW_ORIGIN || '*'}`,
+		// header to `https://example.com`. Multiple domains are supported by verifying that the request
+		// originated from one of the domains in the `CORS_ALLOW_ORIGIN` environment variable.
+		const supportedDomains = env.CORS_ALLOW_ORIGIN ? env.CORS_ALLOW_ORIGIN.split(',') : undefined;
+		const corsHeaders: Record<string, string> = {
 			"Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
 			"Access-Control-Allow-Headers": "*",
+		}
+		if (supportedDomains) {
+			const origin = request.headers.get('Origin')
+			if (origin && supportedDomains.includes(origin)) {
+				corsHeaders['Access-Control-Allow-Origin'] = origin
+			}
+		} else {
+			corsHeaders['Access-Control-Allow-Origin'] = '*'
 		}
 
 		if (request.method === "OPTIONS") {
@@ -26,11 +35,11 @@ export default {
 		}
 
 		const upgradeHeader = request.headers.get('Upgrade')
-    if (upgradeHeader || upgradeHeader === 'websocket') {
-      return await fetch(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, request)
-    }
+		if (upgradeHeader || upgradeHeader === 'websocket') {
+			return await fetch(`https://rpc.helius.xyz/?api-key=${env.HELIUS_API_KEY}`, request)
+		}
 
-		const {pathname, search} = new URL(request.url)
+		const { pathname, search } = new URL(request.url)
 		const payload = await request.text();
 		const proxyRequest = new Request(`https://${pathname === '/' ? 'rpc' : 'api'}.helius.xyz${pathname}?api-key=${env.HELIUS_API_KEY}${search ? `&${search.slice(1)}` : ''}`, {
 			method: request.method,


### PR DESCRIPTION
User can now provide a comma separated list to the `CORS_ALLOW_ORIGIN` environment variable (i.e. `https://example.com,https://another.example.com`). The backend will make the appropriate checks and include or exclude the header.