### PR TITLE
Added optional Devnet URL based on Cloudflare variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ You can now use your worker URL as an the RPC endpoint in all SDK and client sid
 This implementation is intentionally left in a less-than-ideal security state to facilitate easy deployment by anyone. If you would like to
 lock down your RPC proxy further, consider the following steps after you have successfully deployed the worker:
 
-
+## OPTIONAL
+To change your RPC endpoint to devnet, set `IS_DEVNET` = 1 in your Cloudflare variables. The default setting is mainnet.
 * Update the `Access-Control-Allow-Origin` header by adding a new variable with the key name `CORS_ALLOW_ORIGIN` to contain the host that your requests are coming from (usually your client application). For example, if you wanted to allow requests from `https://example.com`, you would change the header to `https://example.com`. To support multiple domains, set `CORS_ALLOW_ORIGIN` to a comma separated list of domains (e.g. `https://example.com,https://beta.example.com`).
 * [Cloudflare Web Application Firewall (WAF)](https://www.cloudflare.com/lp/ppc/waf-x/) - You can configure the WAF to inspect requests and allow/deny based on your own business logic.
 * Modify the IP address allow list in Helius for your API key to only accept connections from the Cloudflare ranges (https://cloudflare.com/ips-v4).

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,9 @@ export default {
     const upgradeHeader = request.headers.get("Upgrade");
     const endpoint_prefix =
       env.IS_DEVNET === "1"
-        ? "https://devnet.helius-rpc.com/"
-        : "https://mainnet.helius-rpc.com/";
+        ? "devnet.helius-rpc.com"
+        : "mainnet.helius-rpc.com";
+
     console.log(endpoint_prefix);
     if (upgradeHeader || upgradeHeader === "websocket") {
       return await fetch(
@@ -48,17 +49,15 @@ export default {
       );
     }
 
-    const { pathname, search } = new URL(request.url);
-    const payload = await request.text();
+    const { pathname, searchParams } = new URL(request.url);
+    const apiUrl = pathname === "/" ? endpoint_prefix : "api.helius.xyz";
+    const search =
+      Array.from(searchParams).length > 0 ? `?${searchParams}` : "";
     const proxyRequest = new Request(
-      `https://${
-        pathname === "/" ? `${endpoint_prefix}` : "api.helius.xyz"
-      }${pathname}?api-key=${env.HELIUS_API_KEY}${
-        search ? `&${search.slice(1)}` : ""
-      }`,
+      `https://${apiUrl}${pathname}?api-key=${env.HELIUS_API_KEY}${search}`,
       {
         method: request.method,
-        body: payload || null,
+        body: request.method !== "GET" ? await request.text() : undefined,
         headers: {
           "Content-Type": "application/json",
           "X-Helius-Cloudflare-Proxy": "true",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 interface Env {
 	CORS_ALLOW_ORIGIN: string;
 	HELIUS_API_KEY: string;
+	IS_DEVNET: boolean;
 }
 
 export default {
@@ -35,10 +36,11 @@ export default {
 		}
 
 		const upgradeHeader = request.headers.get('Upgrade')
+const endpoint_prefix = env.IS_DEVNET ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
+if (upgradeHeader || upgradeHeader === 'websocket') {
+    return await fetch(`${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`, request);
+}
 
-		if (upgradeHeader || upgradeHeader === 'websocket') {
-			return await fetch(`https://mainnet.helius-rpc.com/?api-key=${env.HELIUS_API_KEY}`, request)
-		}
 
 
 		const { pathname, search } = new URL(request.url)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,65 +1,76 @@
 interface Env {
-	CORS_ALLOW_ORIGIN: string;
-	HELIUS_API_KEY: string;
-	IS_DEVNET: string;
+  CORS_ALLOW_ORIGIN: string;
+  HELIUS_API_KEY: string;
+  IS_DEVNET: string;
 }
 
 export default {
-	async fetch(request: Request, env: Env) {
+  async fetch(request: Request, env: Env) {
+    // If the request is an OPTIONS request, return a 200 response with permissive CORS headers
+    // This is required for the Helius RPC Proxy to work from the browser and arbitrary origins
+    // If you wish to restrict the origins that can access your Helius RPC Proxy, you can do so by
+    // changing the `*` in the `Access-Control-Allow-Origin` header to a specific origin.
+    // For example, if you wanted to allow requests from `https://example.com`, you would change the
+    // header to `https://example.com`. Multiple domains are supported by verifying that the request
+    // originated from one of the domains in the `CORS_ALLOW_ORIGIN` environment variable.
+    const supportedDomains = env.CORS_ALLOW_ORIGIN
+      ? env.CORS_ALLOW_ORIGIN.split(",")
+      : undefined;
+    const corsHeaders: Record<string, string> = {
+      "Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    };
+    if (supportedDomains) {
+      const origin = request.headers.get("Origin");
+      if (origin && supportedDomains.includes(origin)) {
+        corsHeaders["Access-Control-Allow-Origin"] = origin;
+      }
+    } else {
+      corsHeaders["Access-Control-Allow-Origin"] = "*";
+    }
 
-		// If the request is an OPTIONS request, return a 200 response with permissive CORS headers
-		// This is required for the Helius RPC Proxy to work from the browser and arbitrary origins
-		// If you wish to restrict the origins that can access your Helius RPC Proxy, you can do so by
-		// changing the `*` in the `Access-Control-Allow-Origin` header to a specific origin.
-		// For example, if you wanted to allow requests from `https://example.com`, you would change the
-		// header to `https://example.com`. Multiple domains are supported by verifying that the request
-		// originated from one of the domains in the `CORS_ALLOW_ORIGIN` environment variable.
-		const supportedDomains = env.CORS_ALLOW_ORIGIN ? env.CORS_ALLOW_ORIGIN.split(',') : undefined;
-		const corsHeaders: Record<string, string> = {
-			"Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, OPTIONS",
-			"Access-Control-Allow-Headers": "*",
-		}
-		if (supportedDomains) {
-			const origin = request.headers.get('Origin')
-			if (origin && supportedDomains.includes(origin)) {
-				corsHeaders['Access-Control-Allow-Origin'] = origin
-			}
-		} else {
-			corsHeaders['Access-Control-Allow-Origin'] = '*'
-		}
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 200,
+        headers: corsHeaders,
+      });
+    }
+    const upgradeHeader = request.headers.get("Upgrade");
+    const endpoint_prefix =
+      env.IS_DEVNET === "1"
+        ? "https://devnet.helius-rpc.com/"
+        : "https://mainnet.helius-rpc.com/";
+    console.log(endpoint_prefix);
+    if (upgradeHeader || upgradeHeader === "websocket") {
+      return await fetch(
+        `${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`,
+        request
+      );
+    }
 
-		if (request.method === "OPTIONS") {
-			return new Response(null, {
-				status: 200,
-				headers: corsHeaders,
-			});
-		}
-	console.log("ENV", env)
-		const upgradeHeader = request.headers.get('Upgrade')
-const endpoint_prefix = env.IS_DEVNET === "1" ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
-		console.log(endpoint_prefix)
-if (upgradeHeader || upgradeHeader === 'websocket') {
-    return await fetch(`${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`, request);
-}
+    const { pathname, search } = new URL(request.url);
+    const payload = await request.text();
+    const proxyRequest = new Request(
+      `https://${
+        pathname === "/" ? `${endpoint_prefix}` : "api.helius.xyz"
+      }${pathname}?api-key=${env.HELIUS_API_KEY}${
+        search ? `&${search.slice(1)}` : ""
+      }`,
+      {
+        method: request.method,
+        body: payload || null,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Helius-Cloudflare-Proxy": "true",
+        },
+      }
+    );
 
-
-
-		const { pathname, search } = new URL(request.url)
-		const payload = await request.text();
-		const proxyRequest = new Request(`https://${pathname === '/' ? 'mainnet.helius-rpc.com' : 'api.helius.xyz'}${pathname}?api-key=${env.HELIUS_API_KEY}${search ? `&${search.slice(1)}` : ''}`, {
-			method: request.method,
-			body: payload || null,
-			headers: {
-				'Content-Type': 'application/json',
-				'X-Helius-Cloudflare-Proxy': 'true',
-			}
-		});
-
-		return await fetch(proxyRequest).then(res => {
-			return new Response(res.body, {
-				status: res.status,
-				headers: corsHeaders
-			});
-		});
-	},
+    return await fetch(proxyRequest).then((res) => {
+      return new Response(res.body, {
+        status: res.status,
+        headers: corsHeaders,
+      });
+    });
+  },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 interface Env {
 	CORS_ALLOW_ORIGIN: string;
 	HELIUS_API_KEY: string;
-	IS_DEVNET: number;
+	IS_DEVNET: string;
 }
 
 export default {
@@ -34,9 +34,9 @@ export default {
 				headers: corsHeaders,
 			});
 		}
-
+	console.log("ENV", env)
 		const upgradeHeader = request.headers.get('Upgrade')
-const endpoint_prefix = env.IS_DEVNET === 1 ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
+const endpoint_prefix = env.IS_DEVNET === "1" ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
 		console.log(endpoint_prefix)
 if (upgradeHeader || upgradeHeader === 'websocket') {
     return await fetch(`${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`, request);

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export default {
 
 		const upgradeHeader = request.headers.get('Upgrade')
 const endpoint_prefix = env.IS_DEVNET ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
+		console.log(endpoint_prefix)
 if (upgradeHeader || upgradeHeader === 'websocket') {
     return await fetch(`${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`, request);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 interface Env {
 	CORS_ALLOW_ORIGIN: string;
 	HELIUS_API_KEY: string;
-	IS_DEVNET: boolean;
+	IS_DEVNET: number;
 }
 
 export default {
@@ -36,7 +36,7 @@ export default {
 		}
 
 		const upgradeHeader = request.headers.get('Upgrade')
-const endpoint_prefix = env.IS_DEVNET ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
+const endpoint_prefix = env.IS_DEVNET === 1 ? 'https://devnet.helius-rpc.com/' : 'https://mainnet.helius-rpc.com/';
 		console.log(endpoint_prefix)
 if (upgradeHeader || upgradeHeader === 'websocket') {
     return await fetch(`${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`, request);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ export default {
         ? "devnet.helius-rpc.com"
         : "mainnet.helius-rpc.com";
 
-    console.log(endpoint_prefix);
     if (upgradeHeader || upgradeHeader === "websocket") {
       return await fetch(
         `${endpoint_prefix}?api-key=${env.HELIUS_API_KEY}`,


### PR DESCRIPTION
I changed the `env` object to have an optional is_devnet var. When the is_devnet is true (represented by a 1), the RPC endpoint is toggled to devnet instead of mainnet. 