### PR TITLE
Add support for DEVNET=true environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /dist
 
 test.js
+.dev.vars

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
 interface Env {
 	CORS_ALLOW_ORIGIN: string;
 	HELIUS_API_KEY: string;
+	DEVNET?: string;
+}
+
+function makeHeliusRpcUrlBase(isDevnet: boolean) {
+	return `${isDevnet ? 'devnet' : 'mainnet'}.helius-rpc.com`
+}
+
+function makeHeliusApiUrlBase(isDevnet: boolean) {
+	return `api${isDevnet ? '-devnet' : ''}.helius.xyz`
 }
 
 export default {
@@ -34,16 +43,20 @@ export default {
 			});
 		}
 
+		const isDevnet = env.DEVNET ? env.DEVNET.toLowerCase() === 'true' : false;
+		const heliusRpcUrlBase = makeHeliusRpcUrlBase(isDevnet);
+		const heliusApiUrlBase = makeHeliusApiUrlBase(isDevnet);
+
 		const upgradeHeader = request.headers.get('Upgrade')
 
 		if (upgradeHeader || upgradeHeader === 'websocket') {
-			return await fetch(`https://mainnet.helius-rpc.com/?api-key=${env.HELIUS_API_KEY}`, request)
+			return await fetch(`https://${heliusRpcUrlBase}/?api-key=${env.HELIUS_API_KEY}`, request)
 		}
 
 
 		const { pathname, search } = new URL(request.url)
 		const payload = await request.text();
-		const proxyRequest = new Request(`https://${pathname === '/' ? 'mainnet.helius-rpc.com' : 'api.helius.xyz'}${pathname}?api-key=${env.HELIUS_API_KEY}${search ? `&${search.slice(1)}` : ''}`, {
+		const proxyRequest = new Request(`https://${pathname === '/' ? heliusRpcUrlBase : heliusApiUrlBase}${pathname}?api-key=${env.HELIUS_API_KEY}${search ? `&${search.slice(1)}` : ''}`, {
 			method: request.method,
 			body: payload || null,
 			headers: {


### PR DESCRIPTION
If the environment variable `DEVNET` is set to true, this will use the devnet RPC and API paths. I used a string comparison to true instead of existence of the variable, so that if someone sees it set to true and changes it to false then they'll get mainnet as they expect.